### PR TITLE
Add multi-arch Docker build GitHub Action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,71 @@
+name: Build and Push Multi-Arch Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to automatically build and push multi-architecture Docker images to GitHub Container Registry (ghcr.io).

## Changes

- ✅ Created `.github/workflows/docker-build.yml` workflow
- ✅ Supports **linux/amd64** and **linux/arm64** architectures
- ✅ Automatically triggers on push to `main`/`master` branch
- ✅ Supports semantic versioning tags (e.g., `v1.0.0`, `v1.0`, `v1`)
- ✅ Pushes images to GitHub Container Registry
- ✅ Includes artifact attestation for supply chain security
- ✅ Uses GitHub Actions cache for faster subsequent builds
- ✅ Supports manual workflow dispatch for testing

## Container Registry

Images will be available at:
```
ghcr.io/tgrecojr/gmailclassifier:latest
ghcr.io/tgrecojr/gmailclassifier:main
ghcr.io/tgrecojr/gmailclassifier:<commit-sha>
```

## Usage

After merge, users can pull the multi-arch image:

```bash
docker pull ghcr.io/tgrecojr/gmailclassifier:latest
```

Docker will automatically pull the correct architecture for their platform (amd64 or arm64).

## Testing

The workflow can be manually triggered from the Actions tab to test before merge.

## Benefits

- 🚀 **Multi-platform support**: Works on Intel/AMD (x86_64) and Apple Silicon (M1/M2/M3)
- 🔒 **Supply chain security**: Artifact attestation for build provenance
- ⚡ **Fast builds**: Layer caching reduces build times
- 🤖 **Automated**: No manual intervention required
- 📦 **Semantic versioning**: Supports version tags for releases

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)