### PR TITLE
Fix Docker build workflow attestation error

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,6 +53,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
Add missing 'id: build' to build-push-action step so that the attestation step can reference the digest via steps.build.outputs.digest

Fixes the error: "One of subject-path or subject-digest must be provided"

🤖 Generated with [Claude Code](https://claude.com/claude-code)