### PR TITLE
Fix Docker build - copy providers directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
 COPY *.py .
+COPY providers/ providers/
 
 # Copy credentials (should be mounted as volume in production)
 # DO NOT build credentials into the image for security


### PR DESCRIPTION
## Problem

The Docker container was crashing on startup with:
```
ModuleNotFoundError: No module named 'providers'
```

This was a **production-breaking bug** - the Docker image couldn't run at all.

## Root Cause

The Dockerfile only copied `*.py` files from the root directory:
```dockerfile
COPY *.py .
```

This missed the entire `providers/` directory, so none of the LLM provider modules were included in the Docker image:
- `providers/bedrock_provider.py`
- `providers/anthropic_provider.py`
- `providers/openai_provider.py`
- `providers/ollama_provider.py`
- `providers/__init__.py`

## Fix

Add explicit copy of the providers directory to the Dockerfile:
```dockerfile
COPY *.py .
COPY providers/ providers/
```

## Testing

The error manifested as:
```
Traceback (most recent call last):
  File "/app/main.py", line 12, in <module>
    from email_classifier_agent import EmailClassifierAgent
  File "/app/email_classifier_agent.py", line 8, in <module>
    from llm_factory import create_llm_provider
  File "/app/llm_factory.py", line 7, in <module>
    from providers.bedrock_provider import BedrockProvider
ModuleNotFoundError: No module named 'providers'
```

After this fix, the providers directory will be copied into the Docker image at `/app/providers/`.

## Impact

- **Severity**: Critical (production broken)
- **Affected**: All Docker deployments
- **Fix**: One-line change to Dockerfile

## Checklist

- [x] Bug fix (fixes production issue)
- [x] Critical severity
- [x] Minimal change (1 line)
- [x] No code changes, only build configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)