### PR TITLE
Add OpenRouter app attribution headers

### DIFF
--- a/openrouter_classifier.py
+++ b/openrouter_classifier.py
@@ -42,6 +42,10 @@ class OpenRouterClassifier:
             self.client = openai.OpenAI(
                 api_key=api_key,
                 base_url="https://openrouter.ai/api/v1",
+                default_headers={
+                    "HTTP-Referer": ("https://github.com/tgrecojr/gmailclassifier"),
+                    "X-Title": "gmailclassifier",
+                },
             )
             self.model = model
             self.temperature = temperature


### PR DESCRIPTION
## Summary

- Added OpenRouter app attribution headers to enable proper tracking in OpenRouter analytics
- App will now show as "gmailclassifier" instead of "unknown" in OpenRouter console
- Enables access to detailed analytics at OpenRouter dashboard

## Changes

- Added `HTTP-Referer` header with GitHub repository URL
- Added `X-Title` header with app name "gmailclassifier"
- Headers are set as `default_headers` in OpenAI client initialization

## Testing

- All 63 tests pass
- Black formatting applied
- Flake8 compliant (new code only; pre-existing warnings remain)

## References

- [OpenRouter App Attribution Documentation](https://openrouter.ai/docs/app-attribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)