### PR TITLE
style: fix black formatting on config.py and tests/conftest.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -129,26 +129,14 @@ if MODEL_CONFIG_PATH:
     except (FileNotFoundError, ValueError) as e:
         print(f"Error loading model config: {e}")
         print("Falling back to environment variables.")
-        OPENROUTER_MODEL = os.getenv(
-            "OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet"
-        )
-        OPENROUTER_TEMPERATURE = float(
-            os.getenv("OPENROUTER_TEMPERATURE", "0.0")
-        )
-        OPENROUTER_MAX_TOKENS = int(
-            os.getenv("OPENROUTER_MAX_TOKENS", "1000")
-        )
+        OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet")
+        OPENROUTER_TEMPERATURE = float(os.getenv("OPENROUTER_TEMPERATURE", "0.0"))
+        OPENROUTER_MAX_TOKENS = int(os.getenv("OPENROUTER_MAX_TOKENS", "1000"))
 else:
     # Fallback to environment variables
-    OPENROUTER_MODEL = os.getenv(
-        "OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet"
-    )
-    OPENROUTER_TEMPERATURE = float(
-        os.getenv("OPENROUTER_TEMPERATURE", "0.0")
-    )
-    OPENROUTER_MAX_TOKENS = int(
-        os.getenv("OPENROUTER_MAX_TOKENS", "1000")
-    )
+    OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet")
+    OPENROUTER_TEMPERATURE = float(os.getenv("OPENROUTER_TEMPERATURE", "0.0"))
+    OPENROUTER_MAX_TOKENS = int(os.getenv("OPENROUTER_MAX_TOKENS", "1000"))
 
 # Gmail Configuration
 GMAIL_CREDENTIALS_PATH = os.getenv("GMAIL_CREDENTIALS_PATH", "credentials.json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import os
 from typing import Dict, List
 from unittest.mock import Mock
 
-
 # Sample test data
 TEST_EMAIL = {
     "id": "test123",


### PR DESCRIPTION
## Summary
- CI installs black unpinned (`.github/workflows/test.yml:99`) and the latest version (26.3.1) collapses function-call line wrapping that an older black had expanded
- Applied `black .` locally — only `config.py` and `tests/conftest.py` change (2 files / 6 ins / 19 del)
- Unblocks every open PR that currently fails the `lint` check

## Test plan
- [x] `black --check .` passes locally (13 files unchanged)
- [ ] CI `lint` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)