### PR TITLE
fix(ci): restore lint + raise coverage to 81.5% (replaces #42)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,10 +9,7 @@ omit =
     venv/*
     setup.py
     */migrations/*
-    # Exclude files without tests (for now)
-    config.py
-    email_classifier_agent.py
-    gmail_client.py
+    # CLI entry-point scripts — thin argparse wrappers, not unit-tested
     main.py
     setup_token.py
     verify_setup.py

--- a/config.py
+++ b/config.py
@@ -129,26 +129,14 @@ if MODEL_CONFIG_PATH:
     except (FileNotFoundError, ValueError) as e:
         print(f"Error loading model config: {e}")
         print("Falling back to environment variables.")
-        OPENROUTER_MODEL = os.getenv(
-            "OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet"
-        )
-        OPENROUTER_TEMPERATURE = float(
-            os.getenv("OPENROUTER_TEMPERATURE", "0.0")
-        )
-        OPENROUTER_MAX_TOKENS = int(
-            os.getenv("OPENROUTER_MAX_TOKENS", "1000")
-        )
+        OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet")
+        OPENROUTER_TEMPERATURE = float(os.getenv("OPENROUTER_TEMPERATURE", "0.0"))
+        OPENROUTER_MAX_TOKENS = int(os.getenv("OPENROUTER_MAX_TOKENS", "1000"))
 else:
     # Fallback to environment variables
-    OPENROUTER_MODEL = os.getenv(
-        "OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet"
-    )
-    OPENROUTER_TEMPERATURE = float(
-        os.getenv("OPENROUTER_TEMPERATURE", "0.0")
-    )
-    OPENROUTER_MAX_TOKENS = int(
-        os.getenv("OPENROUTER_MAX_TOKENS", "1000")
-    )
+    OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet")
+    OPENROUTER_TEMPERATURE = float(os.getenv("OPENROUTER_TEMPERATURE", "0.0"))
+    OPENROUTER_MAX_TOKENS = int(os.getenv("OPENROUTER_MAX_TOKENS", "1000"))
 
 # Gmail Configuration
 GMAIL_CREDENTIALS_PATH = os.getenv("GMAIL_CREDENTIALS_PATH", "credentials.json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import os
 from typing import Dict, List
 from unittest.mock import Mock
 
-
 # Sample test data
 TEST_EMAIL = {
     "id": "test123",

--- a/tests/test_gmail_client.py
+++ b/tests/test_gmail_client.py
@@ -1,0 +1,328 @@
+"""
+Unit tests for gmail_client.py
+"""
+
+import base64
+import pickle
+from unittest.mock import MagicMock, Mock, mock_open, patch
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from gmail_client import GmailClient
+
+
+def _make_http_error(status: int = 500, reason: str = "error") -> HttpError:
+    resp = Mock()
+    resp.status = status
+    resp.reason = reason
+    return HttpError(resp=resp, content=b"")
+
+
+def _b64(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("utf-8")
+
+
+@pytest.fixture
+def client():
+    """A GmailClient with _authenticate bypassed and a mocked service attached."""
+    with patch.object(GmailClient, "_authenticate"):
+        c = GmailClient("creds.json", "token.json", ["scope"])
+    c.service = MagicMock()
+    return c
+
+
+@pytest.mark.unit
+class TestAuthenticate:
+    """Test OAuth/token handling in _authenticate."""
+
+    def test_uses_existing_valid_token(self):
+        creds = MagicMock()
+        creds.valid = True
+        creds.expired = False
+
+        with patch("gmail_client.os.path.exists", return_value=True), patch(
+            "gmail_client.open", mock_open(read_data=b"irrelevant")
+        ), patch("gmail_client.pickle.load", return_value=creds), patch(
+            "gmail_client.build"
+        ) as mock_build:
+            mock_build.return_value = "gmail-service"
+            c = GmailClient("creds.json", "token.json", ["scope"])
+
+        assert c.service == "gmail-service"
+        mock_build.assert_called_once_with("gmail", "v1", credentials=creds)
+
+    def test_refreshes_expired_token(self):
+        creds = MagicMock()
+        creds.valid = False
+        creds.expired = True
+        creds.refresh_token = "refresh"
+
+        with patch("gmail_client.os.path.exists", return_value=True), patch(
+            "gmail_client.open", mock_open(read_data=b"irrelevant")
+        ), patch("gmail_client.pickle.load", return_value=creds), patch(
+            "gmail_client.pickle.dump"
+        ), patch(
+            "gmail_client.build"
+        ):
+            GmailClient("creds.json", "token.json", ["scope"])
+
+        creds.refresh.assert_called_once()
+
+    def test_runs_oauth_flow_when_no_token(self):
+        new_creds = MagicMock()
+
+        with patch("gmail_client.os.path.exists", return_value=False), patch(
+            "gmail_client.InstalledAppFlow"
+        ) as mock_flow_cls, patch("gmail_client.open", mock_open()), patch(
+            "gmail_client.pickle.dump"
+        ) as mock_dump, patch(
+            "gmail_client.build"
+        ):
+            mock_flow = MagicMock()
+            mock_flow.run_local_server.return_value = new_creds
+            mock_flow_cls.from_client_secrets_file.return_value = mock_flow
+
+            GmailClient("creds.json", "token.json", ["scope"], headless=False)
+
+        mock_flow.run_local_server.assert_called_once_with(port=8080)
+        # Credentials get persisted
+        assert mock_dump.called
+
+    def test_headless_mode_uses_console_flow(self):
+        new_creds = MagicMock()
+
+        with patch("gmail_client.os.path.exists", return_value=False), patch(
+            "gmail_client.InstalledAppFlow"
+        ) as mock_flow_cls, patch("gmail_client.open", mock_open()), patch(
+            "gmail_client.pickle.dump"
+        ), patch(
+            "gmail_client.build"
+        ), patch.object(
+            GmailClient, "_run_console_flow", return_value=new_creds
+        ) as mock_console:
+            mock_flow_cls.from_client_secrets_file.return_value = MagicMock()
+            GmailClient("creds.json", "token.json", ["scope"], headless=True)
+
+        mock_console.assert_called_once()
+
+
+@pytest.mark.unit
+class TestGetUnreadMessages:
+    def test_returns_detailed_messages(self, client):
+        client.service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [{"id": "m1"}, {"id": "m2"}]
+        }
+        with patch.object(
+            GmailClient,
+            "_get_message_details",
+            side_effect=[{"id": "m1"}, {"id": "m2"}],
+        ):
+            result = client.get_unread_messages(max_results=5)
+
+        assert [m["id"] for m in result] == ["m1", "m2"]
+
+    def test_returns_empty_list_when_no_messages(self, client):
+        client.service.users.return_value.messages.return_value.list.return_value.execute.return_value = (
+            {}
+        )
+        assert client.get_unread_messages() == []
+
+    def test_skips_messages_whose_details_fail(self, client):
+        client.service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [{"id": "m1"}, {"id": "m2"}]
+        }
+        with patch.object(
+            GmailClient, "_get_message_details", side_effect=[{"id": "m1"}, None]
+        ):
+            result = client.get_unread_messages()
+
+        assert [m["id"] for m in result] == ["m1"]
+
+    def test_http_error_returns_empty_list(self, client):
+        client.service.users.return_value.messages.return_value.list.return_value.execute.side_effect = (
+            _make_http_error()
+        )
+        assert client.get_unread_messages() == []
+
+
+@pytest.mark.unit
+class TestGetMessageDetails:
+    def _payload_with_headers(self, headers, body_text="hello"):
+        return {
+            "payload": {
+                "headers": headers,
+                "body": {"data": _b64(body_text)},
+            },
+            "snippet": "snip",
+        }
+
+    def test_extracts_headers_and_body(self, client):
+        message = self._payload_with_headers(
+            [
+                {"name": "Subject", "value": "Hi"},
+                {"name": "From", "value": "a@b.com"},
+                {"name": "Date", "value": "2026-04-24"},
+            ]
+        )
+        client.service.users.return_value.messages.return_value.get.return_value.execute.return_value = (
+            message
+        )
+
+        result = client._get_message_details("m1")
+
+        assert result["id"] == "m1"
+        assert result["subject"] == "Hi"
+        assert result["from"] == "a@b.com"
+        assert result["date"] == "2026-04-24"
+        assert result["body"] == "hello"
+        assert result["snippet"] == "snip"
+
+    def test_fills_defaults_when_headers_missing(self, client):
+        client.service.users.return_value.messages.return_value.get.return_value.execute.return_value = self._payload_with_headers(
+            []
+        )
+        result = client._get_message_details("m1")
+
+        assert result["subject"] == "No Subject"
+        assert result["from"] == "Unknown"
+        assert result["date"] == "Unknown"
+
+    def test_header_matching_is_case_insensitive(self, client):
+        client.service.users.return_value.messages.return_value.get.return_value.execute.return_value = self._payload_with_headers(
+            [{"name": "subject", "value": "Lower"}]
+        )
+        assert client._get_message_details("m1")["subject"] == "Lower"
+
+    def test_body_truncated_to_5000_chars(self, client):
+        long_text = "x" * 6000
+        client.service.users.return_value.messages.return_value.get.return_value.execute.return_value = {
+            "payload": {"headers": [], "body": {"data": _b64(long_text)}},
+            "snippet": "",
+        }
+        assert len(client._get_message_details("m1")["body"]) == 5000
+
+    def test_http_error_returns_none(self, client):
+        client.service.users.return_value.messages.return_value.get.return_value.execute.side_effect = (
+            _make_http_error()
+        )
+        assert client._get_message_details("m1") is None
+
+
+@pytest.mark.unit
+class TestGetMessageBody:
+    def test_prefers_text_plain_part(self, client):
+        payload = {
+            "parts": [
+                {"mimeType": "text/plain", "body": {"data": _b64("plain-body")}},
+                {"mimeType": "text/html", "body": {"data": _b64("<p>html</p>")}},
+            ]
+        }
+        assert client._get_message_body(payload) == "plain-body"
+
+    def test_falls_back_to_text_html_when_no_plain(self, client):
+        payload = {
+            "parts": [
+                {"mimeType": "text/html", "body": {"data": _b64("<p>html</p>")}},
+            ]
+        }
+        assert client._get_message_body(payload) == "<p>html</p>"
+
+    def test_uses_direct_body_when_no_parts(self, client):
+        payload = {"body": {"data": _b64("direct")}}
+        assert client._get_message_body(payload) == "direct"
+
+    def test_returns_empty_when_no_body(self, client):
+        assert client._get_message_body({}) == ""
+
+    def test_returns_empty_when_part_has_no_data(self, client):
+        payload = {"parts": [{"mimeType": "text/plain", "body": {}}]}
+        assert client._get_message_body(payload) == ""
+
+
+@pytest.mark.unit
+class TestCreateLabelIfNotExists:
+    def test_returns_existing_label_id(self, client):
+        client.service.users.return_value.labels.return_value.list.return_value.execute.return_value = {
+            "labels": [{"id": "L1", "name": "Billing"}]
+        }
+        assert client.create_label_if_not_exists("Billing") == "L1"
+        # Should not attempt to create when already present
+        client.service.users.return_value.labels.return_value.create.assert_not_called()
+
+    def test_creates_new_label_when_missing(self, client):
+        client.service.users.return_value.labels.return_value.list.return_value.execute.return_value = {
+            "labels": []
+        }
+        client.service.users.return_value.labels.return_value.create.return_value.execute.return_value = {
+            "id": "L99",
+            "name": "New",
+        }
+
+        assert client.create_label_if_not_exists("New") == "L99"
+
+    def test_http_error_returns_none(self, client):
+        client.service.users.return_value.labels.return_value.list.return_value.execute.side_effect = (
+            _make_http_error()
+        )
+        assert client.create_label_if_not_exists("Anything") is None
+
+
+@pytest.mark.unit
+class TestAddLabelsToMessage:
+    def test_adds_labels_without_archiving(self, client):
+        client.add_labels_to_message("m1", ["L1", "L2"])
+
+        _, kwargs = (
+            client.service.users.return_value.messages.return_value.modify.call_args
+        )
+        assert kwargs["id"] == "m1"
+        assert kwargs["body"] == {"addLabelIds": ["L1", "L2"]}
+
+    def test_adds_labels_and_archives(self, client):
+        client.add_labels_to_message("m1", ["L1"], remove_from_inbox=True)
+
+        _, kwargs = (
+            client.service.users.return_value.messages.return_value.modify.call_args
+        )
+        assert kwargs["body"]["addLabelIds"] == ["L1"]
+        assert kwargs["body"]["removeLabelIds"] == ["INBOX"]
+
+    def test_http_error_does_not_raise(self, client):
+        client.service.users.return_value.messages.return_value.modify.return_value.execute.side_effect = (
+            _make_http_error()
+        )
+        # Must not raise
+        client.add_labels_to_message("m1", ["L1"])
+
+
+@pytest.mark.unit
+class TestMarkAsRead:
+    def test_removes_unread_label(self, client):
+        client.mark_as_read("m1")
+        _, kwargs = (
+            client.service.users.return_value.messages.return_value.modify.call_args
+        )
+        assert kwargs["body"] == {"removeLabelIds": ["UNREAD"]}
+
+    def test_http_error_does_not_raise(self, client):
+        client.service.users.return_value.messages.return_value.modify.return_value.execute.side_effect = (
+            _make_http_error()
+        )
+        client.mark_as_read("m1")
+
+
+@pytest.mark.unit
+class TestArchiveMessage:
+    def test_removes_inbox_label(self, client):
+        client.archive_message("m1")
+        _, kwargs = (
+            client.service.users.return_value.messages.return_value.modify.call_args
+        )
+        assert kwargs["body"] == {"removeLabelIds": ["INBOX"]}
+
+    def test_http_error_does_not_raise(self, client):
+        client.service.users.return_value.messages.return_value.modify.return_value.execute.side_effect = (
+            _make_http_error()
+        )
+        client.archive_message("m1")

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -18,6 +18,7 @@ from llm_utils import (
 )
 
 
+@pytest.mark.unit
 class TestConstructEmailContent:
     """Test email content construction."""
 
@@ -83,6 +84,7 @@ class TestConstructEmailContent:
         assert "Body:\nNo content" in result
 
 
+@pytest.mark.unit
 class TestConstructClassificationPrompt:
     """Test classification prompt construction."""
 
@@ -115,6 +117,7 @@ class TestConstructClassificationPrompt:
             assert label in result
 
 
+@pytest.mark.unit
 class TestParseLabelsParsing:
     """Test JSON parsing edge cases."""
 
@@ -301,6 +304,7 @@ These labels indicate the primary topics."""
         assert result == ["AWS", "AWS", "Finance"]
 
 
+@pytest.mark.unit
 class TestLogClassificationResult:
     """Test classification result logging."""
 

--- a/tests/test_openrouter_classifier.py
+++ b/tests/test_openrouter_classifier.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for openrouter_classifier.py
+"""
+
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+from openrouter_classifier import OpenRouterClassifier
+
+
+@pytest.fixture
+def sample_email():
+    return {
+        "subject": "Your AWS Bill is Ready",
+        "from": "billing@aws.amazon.com",
+        "date": "2026-04-24",
+        "body": "Your monthly AWS bill is now available.",
+    }
+
+
+@pytest.fixture
+def available_labels():
+    return ["Billing", "Personal", "Work", "Spam"]
+
+
+@pytest.fixture
+def classification_prompt():
+    return "Classify this email into one of the available labels."
+
+
+def _mock_openai_response(content: str):
+    """Build a mock OpenAI SDK chat-completion response whose content is `content`."""
+    message = Mock()
+    message.content = content
+    choice = Mock()
+    choice.message = message
+    response = Mock()
+    response.choices = [choice]
+    return response
+
+
+@pytest.mark.unit
+class TestOpenRouterClassifierInit:
+    """Test OpenRouterClassifier construction."""
+
+    def test_init_stores_defaults(self):
+        with patch("openai.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            classifier = OpenRouterClassifier(api_key="test-key")
+
+        assert classifier.model == "anthropic/claude-3.5-sonnet"
+        assert classifier.temperature == 0.0
+        assert classifier.max_tokens == 1000
+
+    def test_init_stores_custom_values(self):
+        with patch("openai.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            classifier = OpenRouterClassifier(
+                api_key="test-key",
+                model="openai/gpt-4o",
+                temperature=0.5,
+                max_tokens=500,
+            )
+
+        assert classifier.model == "openai/gpt-4o"
+        assert classifier.temperature == 0.5
+        assert classifier.max_tokens == 500
+
+    def test_init_configures_openrouter_base_url(self):
+        with patch("openai.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            OpenRouterClassifier(api_key="test-key")
+
+        _, kwargs = mock_openai.call_args
+        assert kwargs["api_key"] == "test-key"
+        assert kwargs["base_url"] == "https://openrouter.ai/api/v1"
+        assert "HTTP-Referer" in kwargs["default_headers"]
+        assert "X-Title" in kwargs["default_headers"]
+
+
+@pytest.mark.unit
+class TestOpenRouterClassifyEmail:
+    """Test OpenRouterClassifier.classify_email."""
+
+    def _build_classifier(self):
+        with patch("openai.OpenAI") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
+            classifier = OpenRouterClassifier(api_key="test-key")
+        # Replace with a fresh MagicMock so each test controls its own return
+        classifier.client = MagicMock()
+        return classifier
+
+    def test_classify_email_returns_labels(
+        self, sample_email, available_labels, classification_prompt
+    ):
+        classifier = self._build_classifier()
+        classifier.client.chat.completions.create.return_value = _mock_openai_response(
+            '{"labels": ["Billing"]}'
+        )
+
+        result = classifier.classify_email(
+            sample_email, classification_prompt, available_labels
+        )
+
+        assert result == ["Billing"]
+
+    def test_classify_email_calls_model_with_configured_params(
+        self, sample_email, available_labels, classification_prompt
+    ):
+        classifier = self._build_classifier()
+        classifier.model = "openai/gpt-4o"
+        classifier.temperature = 0.3
+        classifier.max_tokens = 750
+        classifier.client.chat.completions.create.return_value = _mock_openai_response(
+            '{"labels": []}'
+        )
+
+        classifier.classify_email(sample_email, classification_prompt, available_labels)
+
+        _, kwargs = classifier.client.chat.completions.create.call_args
+        assert kwargs["model"] == "openai/gpt-4o"
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_tokens"] == 750
+        # system + user messages
+        assert len(kwargs["messages"]) == 2
+        assert kwargs["messages"][0]["role"] == "system"
+        assert kwargs["messages"][1]["role"] == "user"
+
+    def test_classify_email_returns_empty_when_api_errors(
+        self, sample_email, available_labels, classification_prompt
+    ):
+        classifier = self._build_classifier()
+        classifier.client.chat.completions.create.side_effect = RuntimeError("boom")
+
+        result = classifier.classify_email(
+            sample_email, classification_prompt, available_labels
+        )
+
+        assert result == []
+
+    def test_classify_email_filters_unknown_labels(
+        self, sample_email, available_labels, classification_prompt
+    ):
+        classifier = self._build_classifier()
+        classifier.client.chat.completions.create.return_value = _mock_openai_response(
+            '{"labels": ["Billing", "NotARealLabel"]}'
+        )
+
+        result = classifier.classify_email(
+            sample_email, classification_prompt, available_labels
+        )
+
+        assert "Billing" in result
+        assert "NotARealLabel" not in result
+
+    def test_classify_email_handles_empty_label_response(
+        self, sample_email, available_labels, classification_prompt
+    ):
+        classifier = self._build_classifier()
+        classifier.client.chat.completions.create.return_value = _mock_openai_response(
+            '{"labels": []}'
+        )
+
+        result = classifier.classify_email(
+            sample_email, classification_prompt, available_labels
+        )
+
+        assert result == []


### PR DESCRIPTION
## Summary

Consolidated fix for the two CI failures on `main` that have been blocking every Renovate auto-merge since December. Replaces #42 (which only addressed lint).

**Problem**: `main` CI reports **15.5% coverage vs 75% required**, and `black --check` fails on 2 files — so every Renovate PR inherits red CI.

**Root causes found**:
1. Latest `black` (26.3.1) — installed unpinned by `.github/workflows/test.yml` — reformats `config.py` and `tests/conftest.py` in ways the older local version didn't.
2. `test_llm_utils.py`'s 4 test classes were missing `@pytest.mark.unit`, so CI's `pytest -m unit` filter silently deselected **all 31** tests in that file.
3. `.coveragerc` omitted `config.py`, `email_classifier_agent.py`, and `llm_utils.py` as *"files without tests (for now)"* — but each has a full test module already at 73–81% coverage.
4. `openrouter_classifier.py` (23%) and `gmail_client.py` (17%) genuinely had no tests.

## Changes

| Commit | What |
|---|---|
| `style: apply black formatting…` | `black .` run on the 2 files CI complains about |
| `test: mark llm_utils tests as unit and trim stale coverage omits` | `@pytest.mark.unit` on 4 classes; removed stale omits. `main.py`, `setup_token.py`, `verify_setup.py` remain omitted as thin CLI entry scripts. |
| `test: add unit tests for openrouter_classifier and gmail_client` | 8 new tests mocking `openai.OpenAI`; 28 new tests mocking `googleapiclient.discovery.build` + OAuth flow + `HttpError` paths. |

## Coverage impact

| File | Before | After |
|---|---|---|
| `config.py` | omitted | 72.7% |
| `email_classifier_agent.py` | omitted | 77.3% |
| `gmail_client.py` | omitted | **90.8%** (new) |
| `llm_utils.py` | omitted | 80.8% |
| `openrouter_classifier.py` | 23% | **86.7%** (new) |
| **Total** | **15.5%** | **81.5%** |

Unit tests run: **99** (was 32).

## Test plan
- [x] `pytest tests/ -m unit --cov=.` → 99 passed, 81.5% coverage locally
- [x] `black --check .` → 15 files unchanged locally
- [x] `flake8 . --select=E9,F63,F7,F82` → 0 issues
- [ ] CI `test (3.13)` + `lint` jobs pass on this PR
- [ ] Renovate PRs #39, #40, #41 go green once rebased

🤖 Generated with [Claude Code](https://claude.com/claude-code)