### PR TITLE
fix(ci): exclude .venv from flake8 to unblock lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+exclude =
+    .venv,
+    venv,
+    .git,
+    __pycache__,
+    htmlcov,
+    build,
+    dist,
+    *.egg-info
+max-line-length = 127
+max-complexity = 10


### PR DESCRIPTION
## Summary
- After the pip→uv migration (#52), `uv sync --frozen` creates `./.venv/` at the repo root. The lint job runs `uv run flake8 .` which then recursively scans `.venv/` and flags hundreds of issues in third-party packages (`six.py`, `typing_extensions.py`, `pydantic/`, etc.).
- Main has been red on lint since 2026-05-16 as a result, and every open Renovate PR (#53, #54) inherits the failure.
- Add a `.flake8` config at the repo root so flake8 excludes `.venv` (plus `venv`, `htmlcov`, `build`, `dist`, etc.) for both CI and local runs. Also consolidates `max-line-length=127` / `max-complexity=10` which were duplicated as inline flags in `test.yml`.

## Test plan
- [x] Local: `.venv/bin/python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` returns `0` errors.
- [ ] CI: `Run Tests / lint` job passes on this PR.
- [ ] Post-merge: rebase Renovate PRs #53 and #54 (`@renovatebot rebase`) and confirm lint goes green there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)