### PR TITLE
chore: switch Dockerfile base images to Chainguard Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1.24@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 # Gmail Email Classifier - Dockerfile
 
-FROM python:3.14-slim@sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS builder
+FROM cgr.dev/chainguard/python:latest-dev@sha256:c1d503ebc5088bd0143673af0d02f2db31e53acc506ba5a8f4756c337a989d3f AS builder
+
+USER root
 
 COPY --from=ghcr.io/astral-sh/uv:0.11@sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d /uv /uvx /usr/local/bin/
 
@@ -17,23 +19,23 @@ COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
-FROM python:3.14-slim@sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604
+RUN mkdir -p /app/data && chown -R nonroot:nonroot /app
+
+FROM cgr.dev/chainguard/python:latest@sha256:f960fea6d1fb1c0ad626558d9db323ff84468927ac37cd7fa889b512ba0dc1c9
 
 WORKDIR /app
 
-COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder --chown=nonroot:nonroot /app/.venv /app/.venv
+COPY --from=builder --chown=nonroot:nonroot /app/data /app/data
+COPY --chown=nonroot:nonroot *.py ./
 
-ENV PATH="/app/.venv/bin:$PATH"
+ENV PATH="/app/.venv/bin:$PATH" \
+    GMAIL_CREDENTIALS_PATH=/app/credentials.json \
+    GMAIL_TOKEN_PATH=/app/token.json \
+    GMAIL_HEADLESS_MODE=true \
+    CLASSIFIER_CONFIG_PATH=/app/classifier_config.json \
+    MODEL_CONFIG_PATH=/app/model_config.json \
+    STATE_FILE=/app/data/.email_state.json
 
-COPY *.py ./
-
-RUN mkdir -p /app/data
-
-ENV GMAIL_CREDENTIALS_PATH=/app/credentials.json
-ENV GMAIL_TOKEN_PATH=/app/token.json
-ENV GMAIL_HEADLESS_MODE=true
-ENV CLASSIFIER_CONFIG_PATH=/app/classifier_config.json
-ENV MODEL_CONFIG_PATH=/app/model_config.json
-ENV STATE_FILE=/app/data/.email_state.json
-
-CMD ["python", "main.py"]
+ENTRYPOINT ["/app/.venv/bin/python"]
+CMD ["main.py"]


### PR DESCRIPTION
## Summary
- Replace `python:3.14-slim` with `cgr.dev/chainguard/python` for both build (`latest-dev`) and runtime (distroless `latest`) stages to reduce CVE surface
- Both Chainguard images pinned by digest (Renovate-trackable)
- Final image runs as `nonroot` (UID 65532); `/app` and `/app/data` are chowned in the builder before being copied over

## Test plan
- [x] `docker build` succeeds end-to-end
- [x] `docker run` launches Python 3.14.5 and resolves runtime imports (`googleapiclient`, `dotenv`, `requests`)
- [x] Final image inspect shows `User: 65532` (nonroot)
- [ ] CI build + supply-chain workflow pass on this branch
- [ ] Image push + signing + SBOM attestation work against the new base

🤖 Generated with [Claude Code](https://claude.com/claude-code)