### PR TITLE
fix: clear Dockerfile ENTRYPOINT so command overrides work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ ENV PATH="/app/.venv/bin:$PATH" \
     MODEL_CONFIG_PATH=/app/model_config.json \
     STATE_FILE=/app/data/.email_state.json
 
-ENTRYPOINT ["/app/.venv/bin/python"]
-CMD ["main.py"]
+ENTRYPOINT []
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
Follow-up to #70. The Chainguard switch set `ENTRYPOINT ["/app/.venv/bin/python"]`, which broke deployments that pass `python main.py` as the container command — args got appended to the entrypoint and Python tried to execute a script literally named `python`:

```
/app/.venv/bin/python: can't open file '/app/python': [Errno 2] No such file or directory
```

Reset `ENTRYPOINT` to `[]` (Chainguard's base image sets it to `/usr/bin/python`, which has the same problem) and restore `CMD ["python", "main.py"]`. `PATH` already prepends `/app/.venv/bin`, so `python` resolves to the venv binary in both default and override cases.

## Test plan
- [x] `docker build` succeeds
- [x] `docker run <img> python --version` returns Python 3.14.5 (simulates `command: python main.py` override)
- [x] Default CMD resolves to venv python and imports work
- [ ] Redeploy on the affected environment and confirm the classifier starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)