### PR TITLE
chore: migrate actions/attest-sbom to actions/attest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
 
     steps:
       - name: Checkout repository
@@ -81,7 +82,7 @@ jobs:
           upload-release-assets: false
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@v4
+        uses: actions/attest@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## Summary
- Replace deprecated `actions/attest-sbom@v4` with `actions/attest@v4`. The SBOM-specific action was folded into `actions/attest` in v4.0.0 (auto-detects SBOM mode when `sbom-path` is provided).
- Add `artifact-metadata: write` permission now required by `actions/attest` to create the artifact storage record on registry push.
- `actions/attest-build-provenance@v4` left in place — it's not deprecated, just a thin wrapper.

## Test plan
- [ ] Cut a non-PR commit on `main` after merge and confirm the `Attest SBOM` step succeeds in the build job.
- [ ] Verify the SBOM attestation is pushed to GHCR (visible on the package's attestation tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)