### PR TITLE
fix(ci): strip +cpu local versions before pip-audit

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -35,7 +35,13 @@ jobs:
         run: uv python install 3.14
 
       - name: Export locked dependencies to requirements.txt
-        run: uv export --frozen --no-hashes --no-emit-project --output-file requirements-lock.txt
+        run: |
+          uv export --frozen --no-hashes --no-emit-project --output-file requirements-lock.txt
+          # torch is pinned to +cpu wheels from the PyTorch index, which do
+          # not exist on PyPI, so pip-audit's resolver would fail on them.
+          # Strip the local-version suffix: the upstream version is identical
+          # source-wise and is what the advisory databases key on.
+          sed -i 's/+cpu//g' requirements-lock.txt
 
       - name: Socket Security scan
         if: ${{ env.SOCKET_SECURITY_API_KEY != '' }}


### PR DESCRIPTION
## Summary

The supply-chain scan on `main` started failing after #137. Root cause: the lockfile now pins torch to CPU-only wheels (`torch==2.13.0+cpu`) from the PyTorch index to keep multi-GB CUDA packages out of the Docker image — but pip-audit resolves the exported `requirements-lock.txt` against PyPI, where local-version builds don't exist:

```
ERROR: Could not find a version that satisfies the requirement torch==2.13.0+cpu
       (from versions: ..., 2.13.0)
```

The scan died on resolution before auditing anything.

## Fix

Strip the `+cpu` suffix from the exported requirements before pip-audit runs. `torch==2.13.0` exists on PyPI, is source-identical to the `+cpu` build, and is what advisory databases key on — so torch is now **fully audited** rather than skipped (which is why this beats passing `extra-index-urls`, where the local version would be unauditable against the PyPI advisory DB).

The OSV scan is unaffected (it reads `uv.lock` directly and already handles the local version).

## Verification

Ran pip-audit locally against the fixed export: resolves cleanly, **no known vulnerabilities found** — confirming the CI failure was purely the resolution error with no real findings behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)